### PR TITLE
Add PMX, Cycle, Two-Point crossover and fix Order-Based crossover

### DIFF
--- a/pkg/ga/crossover.go
+++ b/pkg/ga/crossover.go
@@ -156,8 +156,59 @@ func MultiPointCrossover(population []*Individual, crossoverRate float64, numPoi
 	return offspring
 }
 
-// OrderBasedCrossover performs an order-based crossover on the given population.
-// This type of crossover is useful for permutation problems (like TSP).
+// TwoPointCrossover performs a two-point crossover on the given population.
+//
+// Two cut points are selected uniformly at random and the genes between them
+// are swapped between the parents to form the two children.
+//
+// Parameters:
+// - population: a slice of pointers to Individual, representing the current population.
+// - crossoverRate: the probability with which crossover will occur.
+//
+// Returns:
+// - A new population of offspring generated from the input population.
+func TwoPointCrossover(population []*Individual, crossoverRate float64) []*Individual {
+	offspring := make([]*Individual, len(population))
+	for i := 0; i < len(population)/2; i++ {
+		if rand.Float64() < crossoverRate {
+			parent1 := population[2*i].Genotype
+			parent2 := population[2*i+1].Genotype
+			genomeLength := len(parent1.Genome)
+			if genomeLength < 3 {
+				// Fall back to single-point semantics for very short genomes.
+				offspring[2*i] = population[2*i]
+				offspring[2*i+1] = population[2*i+1]
+				continue
+			}
+			a := rand.Intn(genomeLength - 1)
+			b := a + 1 + rand.Intn(genomeLength-1-a)
+
+			child1 := &Genotype{Genome: make([]byte, genomeLength), GenomeType: parent1.GenomeType}
+			child2 := &Genotype{Genome: make([]byte, genomeLength), GenomeType: parent2.GenomeType}
+			copy(child1.Genome[:a], parent1.Genome[:a])
+			copy(child1.Genome[a:b], parent2.Genome[a:b])
+			copy(child1.Genome[b:], parent1.Genome[b:])
+			copy(child2.Genome[:a], parent2.Genome[:a])
+			copy(child2.Genome[a:b], parent1.Genome[a:b])
+			copy(child2.Genome[b:], parent2.Genome[b:])
+			offspring[2*i] = &Individual{Genotype: child1}
+			offspring[2*i+1] = &Individual{Genotype: child2}
+		} else {
+			offspring[2*i] = population[2*i]
+			offspring[2*i+1] = population[2*i+1]
+		}
+	}
+	return offspring
+}
+
+// OrderBasedCrossover performs Davis Order Crossover (OX1) on the given population.
+// Suitable for permutation encodings (e.g., TSP): both children remain valid
+// permutations of the parents' shared gene multiset.
+//
+// A random segment [a, b) of parent1 is copied to child1 at the same positions.
+// The remaining positions are filled with parent2's genes in their original
+// order, starting at index b (with wrap-around) and skipping genes already
+// present in the copied segment. child2 is produced symmetrically.
 //
 // Parameters:
 // - population: a slice of pointers to Individual, representing the current population.
@@ -173,30 +224,22 @@ func OrderBasedCrossover(population []*Individual, crossoverRate float64) []*Ind
 			parent1 := population[2*i].Genotype
 			parent2 := population[2*i+1].Genotype
 			genomeLength := len(parent1.Genome)
-
-			// Select a random subset of positions
-			start := rand.Intn(genomeLength)
-			length := rand.Intn(genomeLength - start + 1)
-			end := start + length
-
-			// Create children
-			child1 := &Genotype{Genome: make([]byte, genomeLength)}
-			child2 := &Genotype{Genome: make([]byte, genomeLength)}
-
-			// Initialize with -1 to mark as unfilled
-			for j := 0; j < genomeLength; j++ {
-				child1.Genome[j] = 255 // Sentinel value
-				child2.Genome[j] = 255 // Sentinel value
+			if genomeLength < 2 {
+				offspring[2*i] = population[2*i]
+				offspring[2*i+1] = population[2*i+1]
+				continue
 			}
 
-			// Copy the selected segment from parent to child
-			copy(child1.Genome[start:end], parent1.Genome[start:end])
-			copy(child2.Genome[start:end], parent2.Genome[start:end])
+			a := rand.Intn(genomeLength)
+			b := rand.Intn(genomeLength)
+			if a > b {
+				a, b = b, a
+			}
+			// Use the half-open interval [a, b+1) so the segment is non-empty.
+			end := b + 1
 
-			// Fill the remaining positions in the order they appear in the other parent
-			fillOrderBasedOffspring(parent2.Genome, child1.Genome, start, end)
-			fillOrderBasedOffspring(parent1.Genome, child2.Genome, start, end)
-
+			child1 := &Genotype{Genome: orderCrossoverChild(parent1.Genome, parent2.Genome, a, end), GenomeType: parent1.GenomeType}
+			child2 := &Genotype{Genome: orderCrossoverChild(parent2.Genome, parent1.Genome, a, end), GenomeType: parent2.GenomeType}
 			offspring[2*i] = &Individual{Genotype: child1}
 			offspring[2*i+1] = &Individual{Genotype: child2}
 		} else {
@@ -208,31 +251,190 @@ func OrderBasedCrossover(population []*Individual, crossoverRate float64) []*Ind
 	return offspring
 }
 
-// fillOrderBasedOffspring fills the remaining positions in a child genome for order-based crossover.
-func fillOrderBasedOffspring(parentGenome, childGenome []byte, start, end int) {
-	childIdx := 0
-
-	// Skip positions that are already filled
-	if childIdx == start {
-		childIdx = end
+// orderCrossoverChild builds one OX1 child: copy parent1[start:end] into the
+// child at the same positions, then fill the remaining slots with parent2's
+// genes in their original order starting from index end (with wrap-around),
+// skipping genes already in the copied segment.
+func orderCrossoverChild(p1, p2 []byte, start, end int) []byte {
+	n := len(p1)
+	child := make([]byte, n)
+	used := make(map[byte]bool, end-start)
+	for i := start; i < end; i++ {
+		child[i] = p1[i]
+		used[p1[i]] = true
 	}
+	write := end % n
+	for offset := 0; offset < n; offset++ {
+		gene := p2[(end+offset)%n]
+		if used[gene] {
+			continue
+		}
+		// Skip the segment positions.
+		if write == start {
+			write = end % n
+		}
+		child[write] = gene
+		used[gene] = true
+		write = (write + 1) % n
+		if write == start {
+			write = end % n
+		}
+	}
+	return child
+}
 
-	for _, gene := range parentGenome {
-		// Check if this gene is already in the child
-		alreadyExists := false
-		for j := start; j < end; j++ {
-			if childGenome[j] == gene {
-				alreadyExists = true
+// PMXCrossover performs Partially-Mapped Crossover (PMX) on the given population.
+// Suitable for permutation encodings.
+//
+// A random segment [a, b] of parent1 is copied to child1 at the same positions.
+// The remaining positions are inherited from parent2; any gene already used by
+// the copied segment is resolved by walking a mapping table derived from the
+// two segments until an unused gene is found. child2 is produced symmetrically.
+//
+// Parameters:
+// - population: a slice of pointers to Individual.
+// - crossoverRate: the probability with which crossover will occur.
+//
+// Returns:
+// - A new population of offspring generated from the input population.
+func PMXCrossover(population []*Individual, crossoverRate float64) []*Individual {
+	offspring := make([]*Individual, len(population))
+
+	for i := 0; i < len(population)/2; i++ {
+		if rand.Float64() < crossoverRate {
+			parent1 := population[2*i].Genotype
+			parent2 := population[2*i+1].Genotype
+			n := len(parent1.Genome)
+			if n < 2 {
+				offspring[2*i] = population[2*i]
+				offspring[2*i+1] = population[2*i+1]
+				continue
+			}
+
+			a := rand.Intn(n)
+			b := rand.Intn(n)
+			if a > b {
+				a, b = b, a
+			}
+
+			child1 := &Genotype{Genome: pmxChild(parent1.Genome, parent2.Genome, a, b), GenomeType: parent1.GenomeType}
+			child2 := &Genotype{Genome: pmxChild(parent2.Genome, parent1.Genome, a, b), GenomeType: parent2.GenomeType}
+			offspring[2*i] = &Individual{Genotype: child1}
+			offspring[2*i+1] = &Individual{Genotype: child2}
+		} else {
+			offspring[2*i] = population[2*i]
+			offspring[2*i+1] = population[2*i+1]
+		}
+	}
+	return offspring
+}
+
+// pmxChild builds one PMX child by copying p1[a:b+1] into the child and
+// resolving conflicts in positions outside the segment via the mapping
+// p1[i] -> p2[i] for i in [a, b].
+func pmxChild(p1, p2 []byte, a, b int) []byte {
+	n := len(p1)
+	child := make([]byte, n)
+	copy(child, p2)
+	inSegment := make(map[byte]bool, b-a+1)
+	mapping := make(map[byte]byte, b-a+1)
+	for i := a; i <= b; i++ {
+		child[i] = p1[i]
+		inSegment[p1[i]] = true
+		mapping[p1[i]] = p2[i]
+	}
+	for i := 0; i < n; i++ {
+		if i >= a && i <= b {
+			continue
+		}
+		val := p2[i]
+		seen := make(map[byte]bool)
+		for inSegment[val] {
+			if seen[val] {
+				// Defensive: malformed input (parents not the same multiset).
 				break
 			}
+			seen[val] = true
+			val = mapping[val]
 		}
+		child[i] = val
+	}
+	return child
+}
 
-		if !alreadyExists {
-			childGenome[childIdx] = gene
-			childIdx++
-			if childIdx == start {
-				childIdx = end
+// CycleCrossover performs Cycle Crossover (CX) on the given population.
+// Suitable for permutation encodings.
+//
+// CX identifies the positional cycles between the two parents. Even-indexed
+// cycles take their values from parent1 for child1 (and from parent2 for
+// child2); odd-indexed cycles swap. Every position in each child comes from
+// one of the parents at the same index, so absolute positions are preserved.
+//
+// Parameters:
+// - population: a slice of pointers to Individual.
+// - crossoverRate: the probability with which crossover will occur.
+//
+// Returns:
+// - A new population of offspring generated from the input population.
+func CycleCrossover(population []*Individual, crossoverRate float64) []*Individual {
+	offspring := make([]*Individual, len(population))
+
+	for i := 0; i < len(population)/2; i++ {
+		if rand.Float64() < crossoverRate {
+			parent1 := population[2*i].Genotype
+			parent2 := population[2*i+1].Genotype
+			n := len(parent1.Genome)
+			if n < 2 {
+				offspring[2*i] = population[2*i]
+				offspring[2*i+1] = population[2*i+1]
+				continue
 			}
+
+			c1Genome, c2Genome := cycleCrossoverChildren(parent1.Genome, parent2.Genome)
+			child1 := &Genotype{Genome: c1Genome, GenomeType: parent1.GenomeType}
+			child2 := &Genotype{Genome: c2Genome, GenomeType: parent2.GenomeType}
+			offspring[2*i] = &Individual{Genotype: child1}
+			offspring[2*i+1] = &Individual{Genotype: child2}
+		} else {
+			offspring[2*i] = population[2*i]
+			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	return offspring
+}
+
+func cycleCrossoverChildren(p1, p2 []byte) (child1, child2 []byte) {
+	n := len(p1)
+	child1 = make([]byte, n)
+	child2 = make([]byte, n)
+	visited := make([]bool, n)
+	indexInP2 := make(map[byte]int, n)
+	for i, v := range p2 {
+		indexInP2[v] = i
+	}
+	cycle := 0
+	for start := 0; start < n; start++ {
+		if visited[start] {
+			continue
+		}
+		i := start
+		for !visited[i] {
+			visited[i] = true
+			if cycle%2 == 0 {
+				child1[i] = p1[i]
+				child2[i] = p2[i]
+			} else {
+				child1[i] = p2[i]
+				child2[i] = p1[i]
+			}
+			next, ok := indexInP2[p1[i]]
+			if !ok {
+				// Defensive: malformed input. Break the cycle.
+				break
+			}
+			i = next
+		}
+		cycle++
+	}
+	return child1, child2
 }

--- a/pkg/ga/crossover_test.go
+++ b/pkg/ga/crossover_test.go
@@ -129,3 +129,132 @@ func TestUniformCrossover(t *testing.T) {
 		}
 	}
 }
+
+// permutationPair builds a population of two parents that are random
+// permutations of [0, n).
+func permutationPair(t *testing.T, n int) []*Individual {
+	t.Helper()
+	p1 := make([]byte, n)
+	p2 := make([]byte, n)
+	for i := 0; i < n; i++ {
+		p1[i] = byte(i)
+		p2[i] = byte(n - 1 - i)
+	}
+	return []*Individual{
+		{Genotype: &Genotype{Genome: p1, GenomeType: PermutationEncoding}},
+		{Genotype: &Genotype{Genome: p2, GenomeType: PermutationEncoding}},
+	}
+}
+
+// assertIsPermutation verifies that the genome is a valid permutation of [0, n).
+func assertIsPermutation(t *testing.T, label string, genome []byte) {
+	t.Helper()
+	n := len(genome)
+	seen := make([]bool, n)
+	for _, v := range genome {
+		if int(v) >= n {
+			t.Fatalf("%s: gene %d out of range for permutation of length %d", label, v, n)
+		}
+		if seen[v] {
+			t.Fatalf("%s: duplicate gene %d in genome %v", label, v, genome)
+		}
+		seen[v] = true
+	}
+}
+
+func TestTwoPointCrossover(t *testing.T) {
+	cases := []struct {
+		name           string
+		population     []*Individual
+		crossoverRate  float64
+		expectedLength int
+	}{
+		{
+			name: "crossover occurs",
+			population: []*Individual{
+				{Genotype: &Genotype{Genome: []byte{1, 1, 1, 1, 1, 1, 1, 1}}},
+				{Genotype: &Genotype{Genome: []byte{0, 0, 0, 0, 0, 0, 0, 0}}},
+			},
+			crossoverRate:  1.0,
+			expectedLength: 2,
+		},
+		{
+			name: "no crossover",
+			population: []*Individual{
+				{Genotype: &Genotype{Genome: []byte{1, 1, 1, 1}}},
+				{Genotype: &Genotype{Genome: []byte{0, 0, 0, 0}}},
+			},
+			crossoverRate:  0.0,
+			expectedLength: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			offspring := TwoPointCrossover(tc.population, tc.crossoverRate)
+			if len(offspring) != tc.expectedLength {
+				t.Fatalf("Expected offspring length %d, got %d", tc.expectedLength, len(offspring))
+			}
+			for _, ind := range offspring {
+				if len(ind.Genotype.Genome) != len(tc.population[0].Genotype.Genome) {
+					t.Fatalf("Offspring genome length mismatch")
+				}
+			}
+		})
+	}
+}
+
+// TestOrderBasedCrossoverPreservesPermutation is the regression test for the
+// previously broken OX1 implementation: every child must be a valid
+// permutation of [0, n) when both parents are.
+func TestOrderBasedCrossoverPreservesPermutation(t *testing.T) {
+	for trial := 0; trial < 50; trial++ {
+		population := permutationPair(t, 20)
+		offspring := OrderBasedCrossover(population, 1.0)
+		if len(offspring) != 2 {
+			t.Fatalf("trial %d: expected 2 offspring, got %d", trial, len(offspring))
+		}
+		assertIsPermutation(t, "OX1 child1", offspring[0].Genotype.Genome)
+		assertIsPermutation(t, "OX1 child2", offspring[1].Genotype.Genome)
+	}
+}
+
+func TestPMXCrossoverPreservesPermutation(t *testing.T) {
+	for trial := 0; trial < 50; trial++ {
+		population := permutationPair(t, 20)
+		offspring := PMXCrossover(population, 1.0)
+		if len(offspring) != 2 {
+			t.Fatalf("trial %d: expected 2 offspring, got %d", trial, len(offspring))
+		}
+		assertIsPermutation(t, "PMX child1", offspring[0].Genotype.Genome)
+		assertIsPermutation(t, "PMX child2", offspring[1].Genotype.Genome)
+	}
+}
+
+func TestCycleCrossoverPreservesPermutation(t *testing.T) {
+	for trial := 0; trial < 50; trial++ {
+		population := permutationPair(t, 20)
+		offspring := CycleCrossover(population, 1.0)
+		if len(offspring) != 2 {
+			t.Fatalf("trial %d: expected 2 offspring, got %d", trial, len(offspring))
+		}
+		assertIsPermutation(t, "CX child1", offspring[0].Genotype.Genome)
+		assertIsPermutation(t, "CX child2", offspring[1].Genotype.Genome)
+	}
+}
+
+// CX with identical parents must reproduce them exactly.
+func TestCycleCrossoverIdentityWithIdenticalParents(t *testing.T) {
+	uniq := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	population := []*Individual{
+		{Genotype: &Genotype{Genome: append([]byte(nil), uniq...), GenomeType: PermutationEncoding}},
+		{Genotype: &Genotype{Genome: append([]byte(nil), uniq...), GenomeType: PermutationEncoding}},
+	}
+	offspring := CycleCrossover(population, 1.0)
+	if !reflect.DeepEqual(offspring[0].Genotype.Genome, uniq) {
+		t.Errorf("CX with identical parents: child1 = %v, want %v", offspring[0].Genotype.Genome, uniq)
+	}
+	if !reflect.DeepEqual(offspring[1].Genotype.Genome, uniq) {
+		t.Errorf("CX with identical parents: child2 = %v, want %v", offspring[1].Genotype.Genome, uniq)
+	}
+}


### PR DESCRIPTION
## What

- Add three new crossover operators in `pkg/ga/crossover.go`:
  - `TwoPointCrossover` — two cut points; segment between them is swapped.
  - `PMXCrossover` — Partially-Mapped Crossover for permutation encodings.
  - `CycleCrossover` — Cycle Crossover (CX) for permutation encodings.
- Rewrite `OrderBasedCrossover` (Davis OX1) to actually produce valid permutations. The previous implementation walked the donor parent from index 0 and used a sentinel byte (`255`) plus a write pointer that never wrapped, so it could emit children with duplicate or out-of-range genes. The new implementation walks from the cut point with wrap-around and uses a `used` set to skip already-copied genes.
- Add property-style regression tests that run each permutation crossover 50× and assert each child is a valid permutation of `[0, n)`.

## Why

- Closes a real bug: `OrderBasedCrossover` was unsafe to use on TSP-style problems and there was no test covering the permutation invariant.
- Brings the operator catalogue closer to parity with the sibling `gapy` library, which ships PMX, CX, OX1, and two-point crossover. Future examples (TSP) need these.