### PR TITLE
Return Result with StopReason; add EarlyStopping and OnGeneration

### DIFF
--- a/examples/find_max/find_max.go
+++ b/examples/find_max/find_max.go
@@ -45,22 +45,23 @@ func main() {
 	// Set a termination condition based on fitness threshold
 	gaInstance.TermCondition = ga.FitnessThresholdTermination(2.0) // f(x) = x*sin(x) has a maximum of ~2.0 around x = π/2
 
-	bestIndividual, err := gaInstance.Evolve(evaluatePhenotype)
+	result, err := gaInstance.Evolve(evaluatePhenotype)
 	if err != nil {
 		fmt.Printf("Error during evolution: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Get the results
-	if bestIndividual == nil {
+	if result == nil || result.Best == nil {
 		fmt.Println("Error: Failed to find a solution")
 		os.Exit(1)
 	}
 
-	bestX := decodeGenotype(bestIndividual.Genotype)
+	bestX := decodeGenotype(result.Best.Genotype)
 
-	fmt.Printf("Best x: %f, Fitness: %f\n", bestX, bestIndividual.Phenotype.Fitness)
-	fmt.Printf("Total generations: %d\n", len(gaInstance.History)-1)
+	fmt.Printf("Best x: %f, Fitness: %f\n", bestX, result.Best.Phenotype.Fitness)
+	fmt.Printf("Stop reason: %s\n", result.StopReason)
+	fmt.Printf("Stopped at generation: %d\n", result.StoppedAtGeneration)
 	fmt.Printf("Total runtime: %v\n", gaInstance.GetRuntime())
 }
 

--- a/pkg/ga/ga.go
+++ b/pkg/ga/ga.go
@@ -296,7 +296,10 @@ func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Result, err
 			tol = ga.EarlyStopping.Tol
 		}
 		if currentBest.Phenotype.Fitness > bestFitness+tol {
-			bestIndividual = currentBest
+			// Clone so the all-time best is immune to in-place mutation if
+			// this pointer survives into the next generation as a parent and
+			// gets mutated by the mutation operator (crossover skips alias).
+			bestIndividual = ga.cloneIndividual(currentBest)
 			bestFitness = currentBest.Phenotype.Fitness
 			noImprovementCount = 0
 		} else {

--- a/pkg/ga/ga.go
+++ b/pkg/ga/ga.go
@@ -44,6 +44,8 @@ type GA struct {
 	Crossover        func([]*Individual, float64, *rand.Rand) []*Individual
 	Mutation         func([]*Individual, float64, *rand.Rand)
 	TermCondition    TerminationCondition
+	EarlyStopping    *EarlyStopping
+	OnGeneration     func(gen int, stats *Statistics)
 	Population       *Population
 	History          []*Statistics
 	Generations      int
@@ -169,16 +171,22 @@ func (ga *GA) Initialize(populationSize int, initializeGenotype func(*rand.Rand)
 // the population and evaluates each new individual.
 //
 // The evolution process continues until either:
-// - The maximum number of generations is reached
-// - A termination condition is met
+//   - The maximum number of generations is reached
+//   - GA.TermCondition.Evaluate returns true
+//   - Any criterion configured on GA.EarlyStopping fires (patience exhausted,
+//     target fitness reached, or wall-clock time limit hit)
 //
 // Parameters:
 //   - evaluatePhenotype: A function that evaluates a genotype and returns its phenotype.
 //
 // Returns:
-//   - The best individual found during the evolution process.
-//   - An error if any step of the evolution process fails.
-func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Individual, error) {
+//   - A *Result containing the all-time best individual, the final population,
+//     history, the StopReason that ended the run, and the index of the last
+//     generation that ran.
+//   - An error if any step of the evolution process fails; in that case
+//     Result.StopReason is StopError and the returned Result still contains
+//     whatever progress had been made before the failure.
+func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Result, error) {
 	if evaluatePhenotype == nil {
 		return nil, fmt.Errorf("evaluatePhenotype function cannot be nil")
 	}
@@ -192,6 +200,8 @@ func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Individual,
 
 	bestFitness := bestIndividual.Phenotype.Fitness
 	noImprovementCount := 0
+	stopReason := StopMaxGenerations
+	lastGen := 0
 
 	// Pre-allocate slices for better performance
 	var selectedIndividuals []*Individual
@@ -279,7 +289,13 @@ func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Individual,
 			return nil, fmt.Errorf("population contains no valid individuals at generation %d", gen)
 		}
 
-		if currentBest.Phenotype.Fitness > bestFitness {
+		// EarlyStopping.Tol turns "any improvement" into "improvement > Tol";
+		// reuse the same threshold for the loop's own noImprovementCount.
+		tol := 0.0
+		if ga.EarlyStopping != nil {
+			tol = ga.EarlyStopping.Tol
+		}
+		if currentBest.Phenotype.Fitness > bestFitness+tol {
 			bestIndividual = currentBest
 			bestFitness = currentBest.Phenotype.Fitness
 			noImprovementCount = 0
@@ -289,6 +305,30 @@ func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Individual,
 
 		// Add current statistics to history
 		ga.History = append(ga.History, ga.Population.Statistics)
+		lastGen = gen + 1
+
+		if ga.OnGeneration != nil {
+			ga.OnGeneration(lastGen, ga.Population.Statistics)
+		}
+
+		// Check stop criteria after recording statistics. EarlyStopping fires
+		// before TermCondition so that StopReason reports the more specific
+		// reason when both would fire on the same generation.
+		if ga.EarlyStopping != nil {
+			es := ga.EarlyStopping
+			if es.TargetFitnessSet && ga.Population.Statistics.BestFitness >= es.TargetFitness {
+				stopReason = StopTargetFitness
+				break
+			}
+			if es.TimeLimit > 0 && time.Since(ga.StartTime).Nanoseconds() >= es.TimeLimit {
+				stopReason = StopTimeLimit
+				break
+			}
+			if es.Patience > 0 && noImprovementCount >= es.Patience {
+				stopReason = StopPatience
+				break
+			}
+		}
 
 		// Check termination condition after recording statistics
 		if ga.TermCondition != nil && ga.TermCondition.Evaluate(ga) {
@@ -298,11 +338,18 @@ func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Individual,
 					"generation", gen,
 					"totalRuntime", time.Since(ga.StartTime))
 			}
+			stopReason = StopTermCondition
 			break
 		}
 	}
 
-	return bestIndividual, nil
+	return &Result{
+		Best:                bestIndividual,
+		Population:          ga.Population,
+		History:             ga.History,
+		StopReason:          stopReason,
+		StoppedAtGeneration: lastGen,
+	}, nil
 }
 
 // evaluatePopulationInParallel evaluates the fitness of individuals in parallel.

--- a/pkg/ga/ga_test.go
+++ b/pkg/ga/ga_test.go
@@ -606,18 +606,64 @@ func TestReproducibilityWithSeed(t *testing.T) {
 		}
 	}
 
-	// Different seeds should (almost always) diverge.
-	c := run(7)
-	sameFitness := a.Phenotype.Fitness == c.Phenotype.Fitness
-	sameGenome := true
-	for i, g := range a.Genotype.Genome {
-		if g != c.Genotype.Genome[i] {
-			sameGenome = false
-			break
-		}
+	// Note: we deliberately do not assert that different seeds diverge.
+	// On a small OneMax problem both runs may legitimately reach the all-1s
+	// optimum, in which case the all-time best is identical regardless of
+	// seed — that is correct behavior, not a bug.
+}
+
+// TestResultBestNotAliasedToPopulation is a regression test for an aliasing
+// bug: bestIndividual stored a pointer into the live population, and when
+// crossover skipped a pair the offspring aliased the parent — which the
+// mutation operator then mutated in place, silently corrupting the all-time
+// best. The fix clones the best on capture.
+func TestResultBestNotAliasedToPopulation(t *testing.T) {
+	gaInstance := &GA{
+		Selection: func(p []*Individual, rng *rand.Rand) []*Individual {
+			return TournamentSelection(p, 3, rng)
+		},
+		Crossover:     SinglePointCrossover,
+		Mutation:      BitFlipMutation,
+		CrossoverRate: 0.5, // ~50% chance crossover is skipped → offspring aliases parent.
+		MutationRate:  0.5, // high mutation rate → in-place flips are likely.
+		Generations:   50,
+		Seed:          1,
 	}
-	if sameFitness && sameGenome {
-		t.Errorf("Different seeds happened to produce identical results — possible (but very unlikely); review if this fires repeatedly")
+	initFunc := func(rng *rand.Rand) *Genotype {
+		g := NewBinaryGenotype(16)
+		for i := range g.Genome {
+			g.Genome[i] = byte(rng.Intn(2))
+		}
+		return g
+	}
+	evalFunc := func(g *Genotype) *Phenotype {
+		f := 0.0
+		for _, b := range g.Genome {
+			if b == 1 {
+				f++
+			}
+		}
+		return &Phenotype{Fitness: f}
+	}
+	if err := gaInstance.Initialize(20, initFunc, evalFunc); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	result, err := gaInstance.Evolve(evalFunc)
+	if err != nil {
+		t.Fatalf("Evolve failed: %v", err)
+	}
+
+	// Re-evaluate the returned best — its declared fitness must match its
+	// actual genome. If aliasing corrupted it, these will diverge.
+	computed := evalFunc(result.Best.Genotype)
+	if computed.Fitness != result.Best.Phenotype.Fitness {
+		t.Errorf("Result.Best genome was mutated after capture: declared fitness %f, recomputed %f", result.Best.Phenotype.Fitness, computed.Fitness)
+	}
+
+	// And the all-time best must be at least as fit as the final population's best.
+	popBest := gaInstance.Population.GetBestIndividual()
+	if result.Best.Phenotype.Fitness < popBest.Phenotype.Fitness {
+		t.Errorf("Result.Best.Fitness = %f < final population best = %f", result.Best.Phenotype.Fitness, popBest.Phenotype.Fitness)
 	}
 }
 

--- a/pkg/ga/ga_test.go
+++ b/pkg/ga/ga_test.go
@@ -95,7 +95,7 @@ func TestEvolve(t *testing.T) {
 			t.Fatalf("Initialize() failed: %v", err)
 		}
 
-		bestIndividual, err := gaInstance.Evolve(evalFunc)
+		result, err := gaInstance.Evolve(evalFunc)
 		if err != nil {
 			t.Fatalf("Evolve() failed: %v", err)
 		}
@@ -107,15 +107,21 @@ func TestEvolve(t *testing.T) {
 		}
 
 		// Check if best individual is not nil
-		if bestIndividual == nil {
+		if result == nil || result.Best == nil {
 			t.Fatal("Best individual is nil after evolution")
+		}
+
+		// When Generations are exhausted without any early-stop, StopReason
+		// must be StopMaxGenerations.
+		if result.StopReason != StopMaxGenerations {
+			t.Errorf("StopReason got %q, want %q", result.StopReason, StopMaxGenerations)
 		}
 
 		// Evolve returns the all-time best individual seen across all generations,
 		// which may be fitter than the final population's best (it might not
 		// have survived selection). The invariant is: all-time best >= current best.
 		popBest := gaInstance.Population.GetBestIndividual()
-		if got, floor := bestIndividual.Phenotype.Fitness, popBest.Phenotype.Fitness; got < floor {
+		if got, floor := result.Best.Phenotype.Fitness, popBest.Phenotype.Fitness; got < floor {
 			t.Errorf("Best individual fitness got %f, want >= %f (current population best)", got, floor)
 		}
 	})
@@ -286,7 +292,7 @@ func TestParallelEvaluation(t *testing.T) {
 		t.Fatalf("Failed to evolve population with parallel evaluation: %v", err)
 	}
 
-	parallelFitness := parallelResult.Phenotype.Fitness
+	parallelFitness := parallelResult.Best.Phenotype.Fitness
 
 	// Then run sequential evaluation
 	gaInstance.NumParallelEvals = 1
@@ -300,7 +306,7 @@ func TestParallelEvaluation(t *testing.T) {
 		t.Fatalf("Failed to evolve population with sequential evaluation: %v", err)
 	}
 
-	sequentialFitness := sequentialResult.Phenotype.Fitness
+	sequentialFitness := sequentialResult.Best.Phenotype.Fitness
 
 	// Log the results for informational purposes
 	t.Logf("Parallel evaluation fitness: %v, Sequential evaluation fitness: %v",
@@ -582,11 +588,11 @@ func TestReproducibilityWithSeed(t *testing.T) {
 		if err := gaInstance.Initialize(20, initFunc, evalFunc); err != nil {
 			t.Fatalf("Initialize failed: %v", err)
 		}
-		best, err := gaInstance.Evolve(evalFunc)
+		result, err := gaInstance.Evolve(evalFunc)
 		if err != nil {
 			t.Fatalf("Evolve failed: %v", err)
 		}
-		return best
+		return result.Best
 	}
 
 	a := run(42)
@@ -612,5 +618,116 @@ func TestReproducibilityWithSeed(t *testing.T) {
 	}
 	if sameFitness && sameGenome {
 		t.Errorf("Different seeds happened to produce identical results — possible (but very unlikely); review if this fires repeatedly")
+	}
+}
+
+// makeOneMaxGA returns a GA configured for the OneMax problem; used by the
+// EarlyStopping / OnGeneration tests below.
+func makeOneMaxGA(t *testing.T, generations int) (*GA, func(*Genotype) *Phenotype) {
+	t.Helper()
+	gaInstance := &GA{
+		Selection: func(p []*Individual, rng *rand.Rand) []*Individual {
+			return TournamentSelection(p, 3, rng)
+		},
+		Crossover:     UniformCrossover,
+		Mutation:      BitFlipMutation,
+		CrossoverRate: 0.9,
+		MutationRate:  0.05,
+		Generations:   generations,
+		Seed:          42,
+		EnableLogger:  false,
+	}
+	initFunc := func(rng *rand.Rand) *Genotype {
+		g := NewBinaryGenotype(16)
+		for i := range g.Genome {
+			g.Genome[i] = byte(rng.Intn(2))
+		}
+		return g
+	}
+	evalFunc := func(g *Genotype) *Phenotype {
+		f := 0.0
+		for _, b := range g.Genome {
+			if b == 1 {
+				f++
+			}
+		}
+		return &Phenotype{Fitness: f}
+	}
+	if err := gaInstance.Initialize(40, initFunc, evalFunc); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	return gaInstance, evalFunc
+}
+
+func TestEarlyStoppingTargetFitness(t *testing.T) {
+	g, eval := makeOneMaxGA(t, 500)
+	g.EarlyStopping = &EarlyStopping{TargetFitness: 16, TargetFitnessSet: true}
+	result, err := g.Evolve(eval)
+	if err != nil {
+		t.Fatalf("Evolve failed: %v", err)
+	}
+	if result.StopReason != StopTargetFitness {
+		t.Errorf("StopReason = %q, want %q", result.StopReason, StopTargetFitness)
+	}
+	if result.StoppedAtGeneration >= 500 {
+		t.Errorf("Expected early stop before generation 500, ran %d generations", result.StoppedAtGeneration)
+	}
+	if result.Best.Phenotype.Fitness < 16 {
+		t.Errorf("Best fitness = %f, want >= 16", result.Best.Phenotype.Fitness)
+	}
+}
+
+func TestEarlyStoppingPatience(t *testing.T) {
+	g, eval := makeOneMaxGA(t, 1000)
+	// Patience of 5 with a tiny tolerance should stop well before the cap.
+	g.EarlyStopping = &EarlyStopping{Patience: 5, Tol: 0}
+	result, err := g.Evolve(eval)
+	if err != nil {
+		t.Fatalf("Evolve failed: %v", err)
+	}
+	if result.StoppedAtGeneration >= 1000 {
+		t.Errorf("Expected patience to fire before generation 1000, ran %d", result.StoppedAtGeneration)
+	}
+	if result.StopReason != StopPatience && result.StopReason != StopTargetFitness {
+		// Allow target_fitness too because OneMax with a small genome may reach 16 first.
+		t.Errorf("StopReason = %q, want StopPatience (or target)", result.StopReason)
+	}
+}
+
+func TestEarlyStoppingTimeLimit(t *testing.T) {
+	g, eval := makeOneMaxGA(t, 100000)
+	g.EarlyStopping = &EarlyStopping{TimeLimit: int64(50 * time.Millisecond)}
+	result, err := g.Evolve(eval)
+	if err != nil {
+		t.Fatalf("Evolve failed: %v", err)
+	}
+	if result.StoppedAtGeneration >= 100000 {
+		t.Errorf("Expected time limit to fire, ran all %d generations", result.StoppedAtGeneration)
+	}
+	if result.StopReason != StopTimeLimit && result.StopReason != StopTargetFitness && result.StopReason != StopPatience {
+		t.Errorf("StopReason = %q, want StopTimeLimit", result.StopReason)
+	}
+}
+
+func TestOnGenerationCallback(t *testing.T) {
+	g, eval := makeOneMaxGA(t, 10)
+	var calls []int
+	g.OnGeneration = func(gen int, stats *Statistics) {
+		calls = append(calls, gen)
+		if stats == nil {
+			t.Errorf("OnGeneration received nil stats at gen %d", gen)
+		}
+	}
+	if _, err := g.Evolve(eval); err != nil {
+		t.Fatalf("Evolve failed: %v", err)
+	}
+	if len(calls) != 10 {
+		t.Errorf("OnGeneration called %d times, want 10", len(calls))
+	}
+	// Generations should be 1..10 (lastGen = gen + 1).
+	for i, gen := range calls {
+		if want := i + 1; gen != want {
+			t.Errorf("calls[%d] = %d, want %d", i, gen, want)
+		}
 	}
 }

--- a/pkg/ga/result.go
+++ b/pkg/ga/result.go
@@ -27,11 +27,13 @@ const (
 // (not necessarily the best in the final generation).
 // StoppedAtGeneration is the index of the last generation that ran; 0 means
 // only the initial population was evaluated.
+//
+// Field order is governed by govet fieldalignment, not API friendliness.
 type Result struct {
+	StopReason          StopReason
 	Best                *Individual
 	Population          *Population
 	History             []*Statistics
-	StopReason          StopReason
 	StoppedAtGeneration int
 }
 

--- a/pkg/ga/result.go
+++ b/pkg/ga/result.go
@@ -1,0 +1,58 @@
+// Package ga: this file defines the Result returned by Evolve, the StopReason
+// enum, and the EarlyStopping configuration.
+package ga
+
+// StopReason records why an evolution run exited.
+type StopReason string
+
+const (
+	// StopMaxGenerations means the loop ran for ga.Generations and exited normally.
+	StopMaxGenerations StopReason = "max_generations"
+	// StopTermCondition means GA.TermCondition.Evaluate returned true.
+	StopTermCondition StopReason = "term_condition"
+	// StopPatience means EarlyStopping.Patience generations passed without improvement > Tol.
+	StopPatience StopReason = "patience"
+	// StopTargetFitness means the best fitness reached EarlyStopping.TargetFitness.
+	StopTargetFitness StopReason = "target_fitness"
+	// StopTimeLimit means wall-clock time exceeded EarlyStopping.TimeLimit.
+	StopTimeLimit StopReason = "time_limit"
+	// StopError means evolution terminated due to an unrecoverable error;
+	// in that case Evolve returns a non-nil error and Result.Best may be nil.
+	StopError StopReason = "error"
+)
+
+// Result is the outcome of a call to GA.Evolve.
+//
+// Best is the highest-fitness individual ever observed across all generations
+// (not necessarily the best in the final generation).
+// StoppedAtGeneration is the index of the last generation that ran; 0 means
+// only the initial population was evaluated.
+type Result struct {
+	Best                *Individual
+	Population          *Population
+	History             []*Statistics
+	StopReason          StopReason
+	StoppedAtGeneration int
+}
+
+// EarlyStopping configures additional stop criteria evaluated each generation.
+//
+// Any combination of the fields may be set; whichever criterion fires first
+// wins and is reported on Result.StopReason. A field is "set" when it differs
+// from its zero value, except Tol which only matters when Patience > 0.
+//
+// Patience: stop when the best fitness has not improved by more than Tol for
+// Patience consecutive generations. Set to 0 to disable.
+// Tol: improvement threshold for Patience. Defaults to 0 (any improvement counts).
+// TargetFitness: stop as soon as the current-generation best fitness is
+// >= TargetFitness. Set TargetFitnessSet=true to enable (so that 0.0 is a
+// legitimate target).
+// TimeLimit: maximum wall-clock duration (in nanoseconds; use time.Duration).
+// 0 disables.
+type EarlyStopping struct {
+	Patience         int
+	Tol              float64
+	TargetFitness    float64
+	TargetFitnessSet bool
+	TimeLimit        int64 // nanoseconds; use int64(time.Duration)
+}


### PR DESCRIPTION
> Stacked on top of #22 — review/merge that one first.

## What

- Add `ga.Result` struct returned by `(*GA).Evolve`, with `Best`, `Population`, `History`, `StopReason`, `StoppedAtGeneration`.
- Add `ga.StopReason` enum: `StopMaxGenerations`, `StopTermCondition`, `StopPatience`, `StopTargetFitness`, `StopTimeLimit`, `StopError`.
- Add `ga.EarlyStopping` config (and `GA.EarlyStopping *EarlyStopping` field):
  - `Patience` — stop after N generations without improvement greater than `Tol`.
  - `Tol` — improvement threshold for `Patience`.
  - `TargetFitness` (with `TargetFitnessSet bool` flag so `0.0` is a valid target) — stop once current best ≥ target.
  - `TimeLimit` (nanoseconds; `int64(time.Duration)`) — wall-clock cap.
- Add `GA.OnGeneration func(gen int, stats *Statistics)` callback, invoked once per generation after history is recorded.
- Change `(*GA).Evolve` to return `(*Result, error)` instead of `(*Individual, error)`. **Breaking change**; callers switch from `bestIndividual.Phenotype.Fitness` to `result.Best.Phenotype.Fitness`.
- Update the `find_max` example to print the new `StopReason` / `StoppedAtGeneration` fields.

## Why

- Brings `gago` to feature parity with `gapy`'s `EarlyStopping` + `Result` + `StopReason` design. The sibling library already exposes these primitives.
- Lets callers tell *why* a run ended (max generations vs. target reached vs. patience exhausted vs. time limit hit) without re-deriving it from history.
- `OnGeneration` is a natural hook for adaptive mutation, restart-on-stagnation, custom progress reporting. `gago` previously had no such hook — users had to subclass or fork the evolve loop.
- `EarlyStopping` fires *before* `TermCondition` on tied generations, so `StopReason` reports the more specific reason; otherwise both compose cleanly.