### PR TITLE
Add OneMax, TSP, Knapsack, and Rastrigin examples and run them in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,17 @@ jobs:
 
       - name: run tests
         run: make test
+
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: setup go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: run examples
+        run: ./scripts/run_examples.sh

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ GAGO is a comprehensive Go library for implementing genetic algorithms. The libr
 
 - Crossover operations:
   - Single-point crossover
+  - Two-point crossover
   - Multi-point crossover
   - Uniform crossover
-  - Order-based crossover (for permutations)
+  - Order-based crossover (OX1) for permutations
+  - Partially-mapped crossover (PMX) for permutations
+  - Cycle crossover (CX) for permutations
 
 - Mutation operations:
   - Bit-flip mutation
@@ -43,8 +46,12 @@ GAGO is a comprehensive Go library for implementing genetic algorithms. The libr
   - Convergence threshold
   - Time-based
   - Fitness threshold
+  - Unified `EarlyStopping` config (patience, target fitness, wall-clock time)
 
 - Additional features:
+  - Reproducible runs via `GA.Seed` and a per-instance `*rand.Rand`
+  - Per-generation `OnGeneration` callback
+  - `Result` return value with `StopReason` and `StoppedAtGeneration`
   - Elitism
   - Parallel fitness evaluation
   - Adaptive parameter control
@@ -66,30 +73,34 @@ Here's a simple example of using GAGO to solve a maximization problem:
 func main() {
     // Configure the genetic algorithm
     gaInstance := &ga.GA{
-        Selection:     func(population []*ga.Individual) []*ga.Individual {
-            return ga.TournamentSelection(population, 3)
+        Selection: func(population []*ga.Individual, rng *rand.Rand) []*ga.Individual {
+            return ga.TournamentSelection(population, 3, rng)
         },
         Crossover:     ga.SinglePointCrossover,
         Mutation:      ga.BitFlipMutation,
         CrossoverRate: 0.7,
         MutationRate:  0.01,
         Generations:   100,
+        Seed:          42, // optional; non-zero seeds make runs reproducible
+        EarlyStopping: &ga.EarlyStopping{TargetFitness: targetFitness, TargetFitnessSet: true},
         EnableLogger:  true,
         LogLevel:      logger.LevelInfo,
     }
 
     // Initialize the population
-    gaInstance.Initialize(50, initializeGenotype, evaluatePhenotype)
-
-    // Set termination condition
-    gaInstance.TermCondition = ga.FitnessThresholdTermination(targetFitness)
+    if err := gaInstance.Initialize(50, initializeGenotype, evaluatePhenotype); err != nil {
+        log.Fatal(err)
+    }
 
     // Run the evolution
-    bestIndividual := gaInstance.Evolve(evaluatePhenotype)
+    result, err := gaInstance.Evolve(evaluatePhenotype)
+    if err != nil {
+        log.Fatal(err)
+    }
 
     // Get results
-    fmt.Printf("Best fitness: %f\n", bestIndividual.Phenotype.Fitness)
-    fmt.Printf("Total generations: %d\n", len(gaInstance.History)-1)
+    fmt.Printf("Best fitness: %f\n", result.Best.Phenotype.Fitness)
+    fmt.Printf("Stop reason: %s at generation %d\n", result.StopReason, result.StoppedAtGeneration)
     fmt.Printf("Total runtime: %v\n", gaInstance.GetRuntime())
 }
 ```
@@ -102,9 +113,11 @@ func main() {
   - `population/`: Population and individual management
 - `internal/logger`: Logging functionality
 - `examples/`: Example implementations
-  - `find_max/`: Simple function maximization
-  - `tsp/`: Traveling Salesman Problem solver
-  - More examples to come
+  - `find_max/`: simple 1D function maximization (binary encoding)
+  - `onemax/`: maximize the number of 1s in a binary chromosome
+  - `knapsack/`: 0/1 knapsack with a penalty term for capacity violations
+  - `tsp/`: Travelling Salesman with `OrderBasedCrossover` + `SwapMutation`
+  - `rastrigin/`: 2D Rastrigin function minimization with `GaussianMutation`
 
 ## Error Handling
 

--- a/examples/knapsack/knapsack.go
+++ b/examples/knapsack/knapsack.go
@@ -1,0 +1,102 @@
+// 0/1 Knapsack via GA with a penalty term for capacity violations.
+//
+// Each gene is 1 if the item is taken, 0 otherwise. The fitness is the total
+// value of the chosen items minus a large penalty proportional to how much the
+// chosen weight exceeds the capacity.
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+
+	"github.com/Okabe-Junya/gago/pkg/ga"
+)
+
+type item struct {
+	name   string
+	weight float64
+	value  float64
+}
+
+var items = []item{
+	{"camera", 3.0, 6.0},
+	{"tent", 5.0, 9.0},
+	{"stove", 2.0, 4.0},
+	{"food", 6.0, 12.0},
+	{"water", 4.0, 7.0},
+	{"map", 1.0, 2.0},
+	{"rope", 2.5, 3.5},
+	{"first-aid", 1.5, 5.0},
+	{"flashlight", 1.0, 1.5},
+	{"compass", 0.5, 1.5},
+	{"sleeping-bag", 4.5, 8.0},
+	{"snacks", 2.0, 5.5},
+}
+
+const (
+	capacity       = 15.0
+	populationSize = 50
+	generations    = 300
+	seed           = 42
+)
+
+func main() {
+	gaInstance := &ga.GA{
+		Selection: func(p []*ga.Individual, rng *rand.Rand) []*ga.Individual {
+			return ga.TournamentSelection(p, 3, rng)
+		},
+		Crossover:     ga.UniformCrossover,
+		Mutation:      ga.BitFlipMutation,
+		CrossoverRate: 0.9,
+		MutationRate:  1.0 / float64(len(items)),
+		Generations:   generations,
+		ElitismCount:  2,
+		Seed:          seed,
+	}
+
+	init := func(rng *rand.Rand) *ga.Genotype {
+		g := ga.NewBinaryGenotype(len(items))
+		for i := range g.Genome {
+			g.Genome[i] = byte(rng.Intn(2))
+		}
+		return g
+	}
+	eval := func(g *ga.Genotype) *ga.Phenotype {
+		totalWeight, totalValue := 0.0, 0.0
+		for i, gene := range g.Genome {
+			if gene == 1 {
+				totalWeight += items[i].weight
+				totalValue += items[i].value
+			}
+		}
+		overflow := 0.0
+		if totalWeight > capacity {
+			overflow = totalWeight - capacity
+		}
+		return &ga.Phenotype{Fitness: totalValue - 100.0*overflow}
+	}
+
+	if err := gaInstance.Initialize(populationSize, init, eval); err != nil {
+		fmt.Fprintf(os.Stderr, "Initialize failed: %v\n", err)
+		os.Exit(1)
+	}
+	result, err := gaInstance.Evolve(eval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Evolve failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	weight, value := 0.0, 0.0
+	picked := []string{}
+	for i, gene := range result.Best.Genotype.Genome {
+		if gene == 1 {
+			picked = append(picked, items[i].name)
+			weight += items[i].weight
+			value += items[i].value
+		}
+	}
+	fmt.Printf("Picked %d items: %v\n", len(picked), picked)
+	fmt.Printf("Total weight: %.1f / %.1f\n", weight, capacity)
+	fmt.Printf("Total value:  %.1f\n", value)
+}

--- a/examples/onemax/onemax.go
+++ b/examples/onemax/onemax.go
@@ -1,0 +1,68 @@
+// OneMax: maximize the number of 1s in a binary chromosome.
+//
+// This is the canonical GA baseline problem. With BitFlipMutation and any
+// standard crossover, the GA should reach the all-1s optimum in a few dozen
+// generations.
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+
+	"github.com/Okabe-Junya/gago/pkg/ga"
+)
+
+const (
+	nGenes         = 40
+	populationSize = 60
+	generations    = 200
+	seed           = 42
+)
+
+func main() {
+	gaInstance := &ga.GA{
+		Selection: func(p []*ga.Individual, rng *rand.Rand) []*ga.Individual {
+			return ga.TournamentSelection(p, 3, rng)
+		},
+		Crossover:     ga.UniformCrossover,
+		Mutation:      ga.BitFlipMutation,
+		CrossoverRate: 0.9,
+		MutationRate:  1.0 / nGenes,
+		Generations:   generations,
+		ElitismCount:  2,
+		Seed:          seed,
+		EarlyStopping: &ga.EarlyStopping{TargetFitness: float64(nGenes), TargetFitnessSet: true},
+	}
+
+	init := func(rng *rand.Rand) *ga.Genotype {
+		g := ga.NewBinaryGenotype(nGenes)
+		for i := range g.Genome {
+			g.Genome[i] = byte(rng.Intn(2))
+		}
+		return g
+	}
+	eval := func(g *ga.Genotype) *ga.Phenotype {
+		fitness := 0.0
+		for _, b := range g.Genome {
+			if b == 1 {
+				fitness++
+			}
+		}
+		return &ga.Phenotype{Fitness: fitness}
+	}
+
+	if err := gaInstance.Initialize(populationSize, init, eval); err != nil {
+		fmt.Fprintf(os.Stderr, "Initialize failed: %v\n", err)
+		os.Exit(1)
+	}
+	result, err := gaInstance.Evolve(eval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Evolve failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Best fitness: %d / %d\n", int(result.Best.Phenotype.Fitness), nGenes)
+	fmt.Printf("Best chromosome: %v\n", result.Best.Genotype.Genome)
+	fmt.Printf("Stop reason: %s at generation %d\n", result.StopReason, result.StoppedAtGeneration)
+}

--- a/examples/rastrigin/rastrigin.go
+++ b/examples/rastrigin/rastrigin.go
@@ -1,0 +1,86 @@
+// Minimize the 2D Rastrigin function on the real numbers.
+//
+// The Rastrigin function f(x) = 10n + sum(xi^2 - 10*cos(2*pi*xi)) has a global
+// minimum of 0 at the origin and many local minima, so it is a good stress test
+// for the real-valued GA path (GaussianMutation + UniformCrossover).
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+
+	"github.com/Okabe-Junya/gago/pkg/ga"
+)
+
+const (
+	dim            = 2
+	lower          = -5.12
+	upper          = 5.12
+	populationSize = 80
+	generations    = 400
+	sigma          = 0.3
+	seed           = 42
+)
+
+func rastrigin(x []float64) float64 {
+	total := 10.0 * float64(len(x))
+	for _, xi := range x {
+		total += xi*xi - 10.0*math.Cos(2.0*math.Pi*xi)
+	}
+	return total
+}
+
+func main() {
+	mins := make([]float64, dim)
+	maxs := make([]float64, dim)
+	for i := range mins {
+		mins[i] = lower
+		maxs[i] = upper
+	}
+
+	gaInstance := &ga.GA{
+		Selection: func(p []*ga.Individual, rng *rand.Rand) []*ga.Individual {
+			return ga.TournamentSelection(p, 4, rng)
+		},
+		Crossover: ga.UniformCrossover,
+		Mutation: func(p []*ga.Individual, rate float64, rng *rand.Rand) {
+			ga.GaussianMutation(p, rate, sigma, rng)
+		},
+		CrossoverRate: 0.9,
+		MutationRate:  0.3,
+		Generations:   generations,
+		ElitismCount:  2,
+		Seed:          seed,
+	}
+
+	init := func(rng *rand.Rand) *ga.Genotype {
+		return ga.NewRealGenotype(dim, mins, maxs, rng)
+	}
+	decode := func(g *ga.Genotype) []float64 {
+		out := make([]float64, dim)
+		for i := range out {
+			v, _ := g.GetRealValue(i)
+			out[i] = v
+		}
+		return out
+	}
+	eval := func(g *ga.Genotype) *ga.Phenotype {
+		return &ga.Phenotype{Fitness: -rastrigin(decode(g))}
+	}
+
+	if err := gaInstance.Initialize(populationSize, init, eval); err != nil {
+		fmt.Fprintf(os.Stderr, "Initialize failed: %v\n", err)
+		os.Exit(1)
+	}
+	result, err := gaInstance.Evolve(eval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Evolve failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	point := decode(result.Best.Genotype)
+	fmt.Printf("Best point:  %v\n", point)
+	fmt.Printf("Rastrigin:   %.6f (global min = 0)\n", -result.Best.Phenotype.Fitness)
+}

--- a/examples/tsp/tsp.go
+++ b/examples/tsp/tsp.go
@@ -1,0 +1,88 @@
+// Travelling Salesman Problem with a permutation encoding.
+//
+// Each chromosome is a permutation of city indices representing the visit
+// order. The tour returns to the starting city after the last visit. We
+// minimize total tour length, expressed as a fitness function that returns
+// -length (since gago, like most GAs, treats higher fitness as better).
+//
+// Demonstrates the permutation operators: OrderBasedCrossover (OX1) for
+// recombination and SwapMutation for variation.
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+
+	"github.com/Okabe-Junya/gago/pkg/ga"
+)
+
+const (
+	nCities        = 20
+	populationSize = 100
+	generations    = 500
+	seed           = 42
+)
+
+// cities is a fixed set of points in the unit square, seeded for reproducibility.
+var cities = func() [][2]float64 {
+	r := rand.New(rand.NewSource(2026))
+	out := make([][2]float64, nCities)
+	for i := range out {
+		out[i] = [2]float64{r.Float64(), r.Float64()}
+	}
+	return out
+}()
+
+func tourLength(order []byte) float64 {
+	total := 0.0
+	n := len(order)
+	for i := 0; i < n; i++ {
+		x1, y1 := cities[order[i]][0], cities[order[i]][1]
+		x2, y2 := cities[order[(i+1)%n]][0], cities[order[(i+1)%n]][1]
+		total += math.Hypot(x2-x1, y2-y1)
+	}
+	return total
+}
+
+func main() {
+	gaInstance := &ga.GA{
+		Selection: func(p []*ga.Individual, rng *rand.Rand) []*ga.Individual {
+			return ga.TournamentSelection(p, 4, rng)
+		},
+		Crossover:     ga.OrderBasedCrossover,
+		Mutation:      ga.SwapMutation,
+		CrossoverRate: 0.9,
+		MutationRate:  0.05,
+		Generations:   generations,
+		ElitismCount:  2,
+		Seed:          seed,
+	}
+
+	init := func(rng *rand.Rand) *ga.Genotype {
+		return ga.NewPermutationGenotype(nCities, rng)
+	}
+	eval := func(g *ga.Genotype) *ga.Phenotype {
+		return &ga.Phenotype{Fitness: -tourLength(g.Genome)}
+	}
+
+	if err := gaInstance.Initialize(populationSize, init, eval); err != nil {
+		fmt.Fprintf(os.Stderr, "Initialize failed: %v\n", err)
+		os.Exit(1)
+	}
+	initialBest := -gaInstance.Population.GetBestIndividual().Phenotype.Fitness
+
+	result, err := gaInstance.Evolve(eval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Evolve failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	finalLength := -result.Best.Phenotype.Fitness
+	improvement := (1 - finalLength/initialBest) * 100
+	fmt.Printf("Initial best tour: %.4f\n", initialBest)
+	fmt.Printf("Final   best tour: %.4f\n", finalLength)
+	fmt.Printf("Improvement:       %.1f%%\n", improvement)
+	fmt.Printf("Route: %v\n", result.Best.Genotype.Genome)
+}


### PR DESCRIPTION
## What

- Add four new examples under `examples/`:
  - `onemax/` — maximize the number of 1s in a binary chromosome; uses `EarlyStopping{TargetFitness, TargetFitnessSet: true}` and converges in ~12 generations.
  - `knapsack/` — 0/1 knapsack with a penalty term for capacity violations.
  - `tsp/` — 20-city Travelling Salesman with permutation encoding, `OrderBasedCrossover` (OX1), and `SwapMutation`.
  - `rastrigin/` — 2D Rastrigin function minimization with real-valued encoding and `GaussianMutation`.
- Add an `examples` job to `.github/workflows/test.yml` that runs `./scripts/run_examples.sh` so the examples cannot rot silently.
- Update README's Quick Start to use the new `Result` + `EarlyStopping` API, drop the broken `Selection` closure signature, and add `Seed`. List the new operators (TwoPoint, PMX, CX) and features (`Seed`, `EarlyStopping`, `OnGeneration`, `Result`/`StopReason`).
- Update the `Examples` section of the README to enumerate all five example directories instead of the previous (incorrect) reference to a non-existent `tsp/`.

## Why

- The previous repo shipped a single `find_max` example. The sibling `gapy` library covers four problem archetypes (binary OneMax, binary+constraint Knapsack, permutation TSP, real-valued Rastrigin); porting them gives `gago` the same surface and exercises every encoding and the new permutation crossover operators end-to-end.
- Wiring `run_examples.sh` into CI catches the kind of silent breakage that previously let `OrderBasedCrossover` ship with a permutation-invariance bug for months — there was no example actually exercising it.
- The README's Quick Start was internally inconsistent after the recent breaking changes (#22, #23): updating it makes the README copy-pasteable again.