### PR TITLE
Migrate golangci-lint to v2 config, bump action to v9, fix unchecked error in find_max example (closes #25)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,6 @@ jobs:
           go-version-file: "go.mod"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,38 +1,47 @@
+version: "2"
 run:
   timeout: "20m"
   allow-parallel-runners: true
-  go: "1.23"
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - errcheck
     - gocritic
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - noctx
     - staticcheck
     - unused
-
-linters-settings:
-  govet:
-    enable-all: true
-    disable:
-      - shadow
-  staticcheck:
-    checks: ["-SA1006"]
-
-issues:
-  exclude-use-default: true
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-        - noctx
-        - govet
-
-output:
-  print-linter-name: true
+  settings:
+    govet:
+      disable:
+        - shadow
+      enable-all: true
+    staticcheck:
+      checks:
+        - -SA1006
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+          - govet
+          - noctx
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$

--- a/examples/find_max/find_max.go
+++ b/examples/find_max/find_max.go
@@ -40,7 +40,10 @@ func main() {
 	}
 
 	// Initialize and run the GA
-	gaInstance.Initialize(populationSize, initializeGenotype, evaluatePhenotype)
+	if err := gaInstance.Initialize(populationSize, initializeGenotype, evaluatePhenotype); err != nil {
+		fmt.Printf("Error initializing GA: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Set a termination condition based on fitness threshold
 	gaInstance.TermCondition = ga.FitnessThresholdTermination(2.0) // f(x) = x*sin(x) has a maximum of ~2.0 around x = π/2


### PR DESCRIPTION
## What

- Rewrite `.golangci.yaml` to the v2 schema (`version: \"2\"`, `linters.default: none`, `linters.settings`, `linters.exclusions`, `formatters`).
- Drop `gosimple` from the enabled list (merged into `staticcheck` in v2).
- Remove the stale `run.go: \"1.23\"` pin so golangci-lint reads from `go.mod`.
- Bump `golangci/golangci-lint-action` from v6 to v9.2.0 (SHA-pinned).
- Fix the unchecked `Initialize` error in `examples/find_max` that the v2 lint surfaced (the four other examples already follow this pattern).

## Why

The old config was rejected by golangci-lint v2.x with `unsupported version of the configuration`. CI happened to pass because action v6 pinned an older internal golangci-lint, but anyone running lint locally hit the error immediately. Migrating now keeps the door open for future action upgrades and surfaced a real bug in `find_max`.

## Test plan

- [x] `golangci-lint run` reports zero issues locally with v2.12
- [x] `go test ./...` passes
- [x] `go build ./...` succeeds

Closes #25