### PR TITLE
Prevent nil selection results and clone initial best individual

### DIFF
--- a/pkg/ga/ga.go
+++ b/pkg/ga/ga.go
@@ -197,6 +197,12 @@ func (ga *GA) Evolve(evaluatePhenotype func(*Genotype) *Phenotype) (*Result, err
 	if bestIndividual == nil {
 		return nil, fmt.Errorf("initial population contains no valid individuals")
 	}
+	// Clone so the all-time best is decoupled from the live population. Without
+	// this, gen-0's best can be selected, aliased into offspring via crossover's
+	// pass-through branch, mutated in place, and returned as Result.Best with a
+	// Genome that no longer matches its reported Fitness. The improvement path
+	// below clones for the same reason.
+	bestIndividual = ga.cloneIndividual(bestIndividual)
 
 	bestFitness := bestIndividual.Phenotype.Fitness
 	noImprovementCount := 0

--- a/pkg/ga/ga_test.go
+++ b/pkg/ga/ga_test.go
@@ -667,6 +667,76 @@ func TestResultBestNotAliasedToPopulation(t *testing.T) {
 	}
 }
 
+// TestResultInitialBestClonedAtStart is a regression test for a defect where
+// the all-time best was captured by reference at initialization instead of
+// being cloned. When gen-0's best is never improved upon, that live pointer
+// could be selected, aliased into offspring, mutated in place, and returned as
+// Result.Best with a genome no longer matching its reported fitness.
+//
+// Identity selection and pass-through crossover force every individual —
+// including gen-0's best — to be aliased into the offspring and then mutated in
+// place, so the defect reproduces deterministically regardless of the RNG.
+func TestResultInitialBestClonedAtStart(t *testing.T) {
+	const genomeLength = 8
+
+	identitySelection := func(p []*Individual, rng *rand.Rand) []*Individual {
+		selected := make([]*Individual, len(p))
+		copy(selected, p)
+		return selected
+	}
+	passthroughCrossover := func(p []*Individual, rate float64, rng *rand.Rand) []*Individual {
+		offspring := make([]*Individual, len(p))
+		copy(offspring, p)
+		return offspring
+	}
+	evalFunc := func(g *Genotype) *Phenotype {
+		f := 0.0
+		for _, b := range g.Genome {
+			if b == 1 {
+				f++
+			}
+		}
+		return &Phenotype{Fitness: f}
+	}
+	// Every individual starts all-ones (the unbeatable maximum); a mutation rate
+	// of 1.0 flips every bit, degrading any in-place-mutated alias to fitness 0.
+	initFunc := func(rng *rand.Rand) *Genotype {
+		g := NewBinaryGenotype(genomeLength)
+		for i := range g.Genome {
+			g.Genome[i] = 1
+		}
+		return g
+	}
+
+	gaInstance := &GA{
+		Selection:     identitySelection,
+		Crossover:     passthroughCrossover,
+		Mutation:      BitFlipMutation,
+		CrossoverRate: 1.0,
+		MutationRate:  1.0,
+		Generations:   1,
+		Seed:          1,
+	}
+	if err := gaInstance.Initialize(10, initFunc, evalFunc); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	result, err := gaInstance.Evolve(evalFunc)
+	if err != nil {
+		t.Fatalf("Evolve failed: %v", err)
+	}
+
+	// Post-fix the initial best is a clone immune to in-place mutation, so it
+	// retains the all-ones genome and fitness genomeLength.
+	if result.Best.Phenotype.Fitness != float64(genomeLength) {
+		t.Errorf("Result.Best.Fitness = %f, want %d (initial best was aliased and mutated)", result.Best.Phenotype.Fitness, genomeLength)
+	}
+	computed := evalFunc(result.Best.Genotype)
+	if computed.Fitness != result.Best.Phenotype.Fitness {
+		t.Errorf("Result.Best genome does not match reported fitness: declared %f, recomputed %f", result.Best.Phenotype.Fitness, computed.Fitness)
+	}
+}
+
 // makeOneMaxGA returns a GA configured for the OneMax problem; used by the
 // EarlyStopping / OnGeneration tests below.
 func makeOneMaxGA(t *testing.T, generations int) (*GA, func(*Genotype) *Phenotype) {

--- a/pkg/ga/selection.go
+++ b/pkg/ga/selection.go
@@ -36,6 +36,25 @@ func TournamentSelection(population []*Individual, tournamentSize int, rng *rand
 	return selected
 }
 
+// isUsableTotalWeight reports whether a total weight is a finite, strictly
+// positive number, i.e. usable as a denominator for proportional selection.
+// Non-positive totals (e.g. all-negative fitness used for minimization) or
+// non-finite totals (NaN/Inf) make proportional selection undefined.
+func isUsableTotalWeight(total float64) bool {
+	return total > 0 && !math.IsInf(total, 1)
+}
+
+// uniformSelection returns len(population) individuals chosen uniformly at
+// random with replacement. Used as a fallback when proportional selection is
+// undefined so the returned slice never contains nil entries.
+func uniformSelection(population []*Individual, rng *rand.Rand) []*Individual {
+	selected := make([]*Individual, len(population))
+	for i := range selected {
+		selected[i] = population[rng.Intn(len(population))]
+	}
+	return selected
+}
+
 // RouletteWheelSelection implements roulette wheel selection for selecting individuals.
 // The probability of selection is proportional to the individual's fitness.
 func RouletteWheelSelection(population []*Individual, rng *rand.Rand) []*Individual {
@@ -49,6 +68,12 @@ func RouletteWheelSelection(population []*Individual, rng *rand.Rand) []*Individ
 		totalFitness += ind.Phenotype.Fitness
 	}
 
+	// Proportional selection is only defined for a positive, finite total.
+	// Fall back to uniform selection to avoid nil entries in the result.
+	if !isUsableTotalWeight(totalFitness) {
+		return uniformSelection(population, rng)
+	}
+
 	// Create cumulative fitness array
 	cumulativeFitness := make([]float64, len(population))
 	cumulativeFitness[0] = population[0].Phenotype.Fitness / totalFitness
@@ -60,6 +85,10 @@ func RouletteWheelSelection(population []*Individual, rng *rand.Rand) []*Individ
 	selected := make([]*Individual, len(population))
 	for i := range selected {
 		r := rng.Float64()
+		// Default to the last bucket: floating-point rounding can leave the
+		// final cumulative value just below r, which would otherwise leave
+		// this slot nil.
+		selected[i] = population[len(population)-1]
 		for j, cumFitness := range cumulativeFitness {
 			if r <= cumFitness {
 				selected[i] = population[j]
@@ -111,6 +140,9 @@ func RankSelection(population []*Individual, rng *rand.Rand) []*Individual {
 	selected := make([]*Individual, len(population))
 	for i := range selected {
 		r := rng.Float64()
+		// Default to the last bucket to guard against floating-point rounding
+		// leaving the final cumulative probability just below r.
+		selected[i] = sorted[len(sorted)-1]
 		for j, prob := range probabilities {
 			if r <= prob {
 				selected[i] = sorted[j]
@@ -134,11 +166,20 @@ func RankSelection(population []*Individual, rng *rand.Rand) []*Individual {
 // - A new population of selected individuals.
 func StochasticUniversalSamplingSelection(population []*Individual, rng *rand.Rand) []*Individual {
 	n := len(population)
+	if n == 0 {
+		return nil
+	}
 	selected := make([]*Individual, n)
 	totalFitness := 0.0
 
 	for _, ind := range population {
 		totalFitness += ind.Phenotype.Fitness
+	}
+
+	// SUS requires a positive, finite total; otherwise fall back to uniform
+	// selection to avoid nil entries in the result.
+	if !isUsableTotalWeight(totalFitness) {
+		return uniformSelection(population, rng)
 	}
 
 	// Calculate the distance between the pointers
@@ -151,6 +192,9 @@ func StochasticUniversalSamplingSelection(population []*Individual, rng *rand.Ra
 	for i := range selected {
 		pointer := start + float64(i)*distance
 		current := 0.0
+		// Default to the last individual so floating-point rounding on the
+		// final pointer cannot leave this slot nil.
+		selected[i] = population[n-1]
 		for _, ind := range population {
 			current += ind.Phenotype.Fitness
 			if current > pointer {
@@ -218,6 +262,9 @@ func TruncationSelection(population []*Individual, truncationThreshold float64) 
 // - A new population of selected individuals.
 func BoltzmannSelection(population []*Individual, temperature float64, rng *rand.Rand) []*Individual {
 	n := len(population)
+	if n == 0 {
+		return nil
+	}
 	selected := make([]*Individual, n)
 
 	// Calculate Boltzmann probabilities
@@ -230,11 +277,21 @@ func BoltzmannSelection(population []*Individual, temperature float64, rng *rand
 		totalBoltzmann += boltzmannValues[i]
 	}
 
+	// math.Exp can overflow to +Inf (or a non-positive temperature can yield
+	// NaN); fall back to uniform selection when the total weight is unusable
+	// to avoid nil entries in the result.
+	if !isUsableTotalWeight(totalBoltzmann) {
+		return uniformSelection(population, rng)
+	}
+
 	// Perform selection based on Boltzmann probabilities
 	for i := range selected {
 		pick := rng.Float64() * totalBoltzmann
 		current := 0.0
 
+		// Default to the last individual so floating-point rounding cannot
+		// leave this slot nil.
+		selected[i] = population[n-1]
 		for j, ind := range population {
 			current += boltzmannValues[j]
 			if current > pick {

--- a/pkg/ga/selection_test.go
+++ b/pkg/ga/selection_test.go
@@ -1,6 +1,7 @@
 package ga
 
 import (
+	"math"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -95,6 +96,59 @@ func TestRouletteWheelSelection(t *testing.T) {
 			if !found {
 				t.Errorf("Selected individual %+v not found in the original population", ind)
 			}
+		}
+	}
+}
+
+// TestProportionalSelectionNoNilEntries is a regression test for a defect where
+// proportional selectors assigned selected[i] only inside the inner selection
+// loop with no fallback. Non-positive total fitness (common for minimization,
+// where fitness is negative), NaN/Inf weights, or floating-point rounding could
+// leave nil entries, which panic when later dereferenced during crossover.
+func TestProportionalSelectionNoNilEntries(t *testing.T) {
+	fitnessSets := map[string][]float64{
+		"all-negative": {-1.0, -2.0, -3.0, -4.0},
+		"all-zero":     {0.0, 0.0, 0.0, 0.0},
+		"mixed-sign":   {-2.0, 1.0, -3.0, 4.0},
+		"nan":          {math.NaN(), -1.0, 2.0, -3.0},
+	}
+
+	selectors := map[string]func([]*Individual, *rand.Rand) []*Individual{
+		"RouletteWheelSelection":               RouletteWheelSelection,
+		"RankSelection":                        RankSelection,
+		"StochasticUniversalSamplingSelection": StochasticUniversalSamplingSelection,
+		"BoltzmannSelection": func(pop []*Individual, rng *rand.Rand) []*Individual {
+			return BoltzmannSelection(pop, 1.0, rng)
+		},
+		// A tiny temperature drives math.Exp to overflow to +Inf, exercising the
+		// non-finite total-weight fallback path.
+		"BoltzmannSelectionOverflow": func(pop []*Individual, rng *rand.Rand) []*Individual {
+			return BoltzmannSelection(pop, 1e-6, rng)
+		},
+	}
+
+	for setName, fitnesses := range fitnessSets {
+		for selName, sel := range selectors {
+			t.Run(setName+"/"+selName, func(t *testing.T) {
+				rng := rand.New(rand.NewSource(1))
+				population := make([]*Individual, len(fitnesses))
+				for i, f := range fitnesses {
+					population[i] = &Individual{
+						Genotype:  &Genotype{Genome: []byte{byte(i)}},
+						Phenotype: &Phenotype{Fitness: f},
+					}
+				}
+
+				selected := sel(population, rng)
+				if len(selected) != len(population) {
+					t.Fatalf("expected %d selected, got %d", len(population), len(selected))
+				}
+				for i, ind := range selected {
+					if ind == nil {
+						t.Fatalf("selected[%d] is nil (would panic on later dereference)", i)
+					}
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
## What

- Make the proportional selectors (`RouletteWheelSelection`, `StochasticUniversalSamplingSelection`, `BoltzmannSelection`, `RankSelection`) always return a fully populated slice with no `nil` entries.
- Clone the initial all-time best individual at the start of `Evolve` instead of holding a reference into the live population.
- Add regression tests for both defects.

## Why

**1. Proportional selectors could return `nil` entries, causing a nil-dereference panic.**

These selectors assigned `selected[i]` only inside the inner selection loop, with no fallback. Two triggers left a slot `nil`:

- Non-positive or non-finite total weight. Minimization uses negative fitness (e.g. `Fitness: -tourLength`), so every cumulative term is `<= 0` or `NaN` and the `r ∈ [0,1)` comparison never matches; `math.Exp` in Boltzmann selection can also overflow to `+Inf`.
- Floating-point rounding leaving the final cumulative bucket just below `r`.

A `nil` entry is later dereferenced in `SinglePointCrossover` (`population[2*i].Genotype`), panicking on the main goroutine — the recover only guards parallel fitness evaluation, so this crashes the run. Each affected selector now falls back to uniform random selection when the total weight is not positive-finite, and defaults every slot to the last bucket so rounding cannot leave it unset. A shared `isUsableTotalWeight` / `uniformSelection` helper keeps the fix consistent.

**2. The initial all-time best was stored by reference, not cloned.**

`Evolve` captured `ga.Population.GetBestIndividual()` as a pointer into the live population. The improvement path already clones for this reason, but the initial assignment did not. When gen-0's best is never improved upon, that live pointer can be selected, aliased into offspring via crossover's pass-through branch, mutated in place, and returned as `Result.Best` with a genome that no longer matches its reported fitness. The initial best is now cloned via `cloneIndividual`, matching the improvement path.
