### PR TITLE
Set least-privilege token permissions on CI workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: lint / golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   go-mod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Add a top-level `permissions: contents: read` block to the `go test` and `golangci-lint` workflows.

## Why
Both workflows ran with the repository-default `GITHUB_TOKEN` permissions instead of an explicit least-privilege scope, which GitHub code scanning flagged as `actions/missing-workflow-permissions` (4 alerts). Every job is read-only (checkout, go test, lint, examples), so `contents: read` is sufficient and removes write/PR-approval capability from a potentially compromised action.