### PR TITLE
Carry over unpaired individual on odd-sized populations to fix crossover nil panic

### DIFF
--- a/pkg/ga/crossover.go
+++ b/pkg/ga/crossover.go
@@ -7,6 +7,18 @@ import (
 	"sort"
 )
 
+// carryOverOddTail copies the final unpaired individual into the offspring when
+// the population size is odd. The pairwise crossover loops only fill indices
+// [0, 2*(len(population)/2)), so for an odd population the last slot would
+// otherwise remain nil and cause a nil dereference in downstream operators
+// (e.g. mutation). This preserves crossover semantics for even populations.
+func carryOverOddTail(offspring, population []*Individual) {
+	if len(population)%2 == 1 {
+		last := len(population) - 1
+		offspring[last] = population[last]
+	}
+}
+
 // SinglePointCrossover performs a single-point crossover on the given population.
 //
 // In single-point crossover, a random crossover point is selected, and the
@@ -39,6 +51,7 @@ func SinglePointCrossover(population []*Individual, crossoverRate float64, rng *
 			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 
@@ -78,6 +91,7 @@ func UniformCrossover(population []*Individual, crossoverRate float64, rng *rand
 			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 
@@ -153,6 +167,7 @@ func MultiPointCrossover(population []*Individual, crossoverRate float64, numPoi
 			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 
@@ -198,6 +213,7 @@ func TwoPointCrossover(population []*Individual, crossoverRate float64, rng *ran
 			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 
@@ -248,6 +264,7 @@ func OrderBasedCrossover(population []*Individual, crossoverRate float64, rng *r
 		}
 	}
 
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 
@@ -326,6 +343,7 @@ func PMXCrossover(population []*Individual, crossoverRate float64, rng *rand.Ran
 			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 
@@ -400,6 +418,7 @@ func CycleCrossover(population []*Individual, crossoverRate float64, rng *rand.R
 			offspring[2*i+1] = population[2*i+1]
 		}
 	}
+	carryOverOddTail(offspring, population)
 	return offspring
 }
 

--- a/pkg/ga/crossover_test.go
+++ b/pkg/ga/crossover_test.go
@@ -3,6 +3,7 @@ package ga
 import (
 	"math/rand"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -247,6 +248,77 @@ func TestCycleCrossoverPreservesPermutation(t *testing.T) {
 		}
 		assertIsPermutation(t, "CX child1", offspring[0].Genotype.Genome)
 		assertIsPermutation(t, "CX child2", offspring[1].Genotype.Genome)
+	}
+}
+
+// oddPopulation builds a population of the given odd size where every
+// individual is a valid permutation of [0, genomeLen), so it is usable by both
+// the binary/point crossovers and the permutation crossovers (OX1, PMX, CX).
+func oddPopulation(size, genomeLen int, rng *rand.Rand) []*Individual {
+	population := make([]*Individual, size)
+	for i := range population {
+		population[i] = &Individual{Genotype: NewPermutationGenotype(genomeLen, rng)}
+	}
+	return population
+}
+
+// TestCrossoverOddPopulationNoNilTail is the regression test for the odd-sized
+// population bug: the pairwise crossover loop only filled indices
+// [0, 2*(len/2)), leaving offspring[len-1] nil for odd populations, which
+// panicked downstream (mutation) on a nil *Individual. Every returned slot must
+// be a fully-formed individual.
+func TestCrossoverOddPopulationNoNilTail(t *testing.T) {
+	t.Parallel()
+
+	const genomeLen = 6
+
+	crossovers := []struct {
+		name string
+		fn   func([]*Individual, float64, *rand.Rand) []*Individual
+	}{
+		{"SinglePointCrossover", SinglePointCrossover},
+		{"UniformCrossover", UniformCrossover},
+		{"MultiPointCrossover", func(p []*Individual, r float64, rng *rand.Rand) []*Individual {
+			return MultiPointCrossover(p, r, 2, rng)
+		}},
+		{"TwoPointCrossover", TwoPointCrossover},
+		{"OrderBasedCrossover", OrderBasedCrossover},
+		{"PMXCrossover", PMXCrossover},
+		{"CycleCrossover", CycleCrossover},
+	}
+
+	sizes := []int{3, 5}
+
+	for _, cx := range crossovers {
+		cx := cx
+		t.Run(cx.name, func(t *testing.T) {
+			t.Parallel()
+			for _, size := range sizes {
+				size := size
+				t.Run("size="+strconv.Itoa(size), func(t *testing.T) {
+					t.Parallel()
+					rng := rand.New(rand.NewSource(int64(size)))
+					population := oddPopulation(size, genomeLen, rng)
+
+					offspring := cx.fn(population, 1.0, rng)
+
+					if len(offspring) != size {
+						t.Fatalf("expected %d offspring, got %d", size, len(offspring))
+					}
+					for i, ind := range offspring {
+						if ind == nil {
+							t.Fatalf("offspring[%d] is nil", i)
+						}
+						if ind.Genotype == nil {
+							t.Fatalf("offspring[%d].Genotype is nil", i)
+						}
+						if got := len(ind.Genotype.Genome); got != genomeLen {
+							t.Fatalf("offspring[%d] genome length = %d, want %d", i, got, genomeLen)
+						}
+					}
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Carry the unpaired individual over to the offspring slice when a crossover runs on an odd-sized population, across all seven crossover operators (`SinglePointCrossover`, `UniformCrossover`, `MultiPointCrossover`, `TwoPointCrossover`, `OrderBasedCrossover`, `PMXCrossover`, `CycleCrossover`) via a shared `carryOverOddTail` helper. Adds a table-driven regression test that runs every operator on populations of size 3 and 5 and asserts no offspring slot is nil.

## Why

Each operator allocated `offspring := make([]*Individual, len(population))` but only iterated `len(population)/2` times. With an odd population size the final slot was left as a nil `*Individual`, so the next pipeline step (mutation) dereferenced nil and panicked. Found by a portfolio-wide multi-agent audit and confirmed by adversarial verification; the new test fails on `main` without this fix.

## Related

ref. Okabe-Junya/sandbox.internal#639
